### PR TITLE
auto-close student project grade

### DIFF
--- a/background.js
+++ b/background.js
@@ -42,6 +42,15 @@ function init() {
                         sendReportToGradesServer(gradesServerOverviewTab, request.report);
                     }
                 );
+            } else if (request.action === "closeSendersTab") {
+                // wait for 1 seconds before closing tab
+                
+                setTimeout(
+                    function () {
+                        chrome.tabs.remove(sender.tab.id);
+                    },
+                    1000
+                );
             }
         }
     );

--- a/grades_server_main.js
+++ b/grades_server_main.js
@@ -41,6 +41,18 @@ function addListenerForGradingResult() {
 
                     $(scoreAdjustmentInput).val(adjustmentValue.toString());
                 }
+                const saveChangesButton = "form input[value=\"Save Changes\"]";
+
+                // closes current tab
+                $(saveChangesButton).on("click", function () {
+                    
+                    // need to send a message back to background script to close this tab
+                    chrome.runtime.sendMessage({
+                        action: "closeSendersTab"
+                    }, function (response) {})
+                    
+                })
+               
             }
         }
     );


### PR DESCRIPTION
TL;DR of how it works. Content script now has a listener that checks if the "Save Changes" button is clicked. When clicked, we send a message from the content script to the background script to wait for 1 second(we need to give the "Save Changes" call time to process if not the tab closes without anything happen) and the tab is closed. 

For a slight improvement, we should technically wait for the page to refresh instead of waiting for 1 second, but it should not make a difference unless the user's wifi is really bad.