### PR TITLE
Show only students that are specified in configuration json

### DIFF
--- a/options.js
+++ b/options.js
@@ -36,6 +36,7 @@ class Options {
         this.submitServerAssignmentName = submitServerAssignmentName;
         this.filesToCheck = filesToCheck;
         this.lateScoreAdjustment = -12;
+        this.students = "*";
         this.moduleOptions = {
             "brace_style_module": brace_style_module.getDefaultOptions(),
             "grade_server_module": grade_server_module.getDefaultOptions(),

--- a/options.js
+++ b/options.js
@@ -37,7 +37,9 @@ class Options {
         this.filesToCheck = filesToCheck;
         this.lateScoreAdjustment = -12;
         this.firstStudent = "a";
-        this.lastStudent = "z";
+        // To include directory IDs that start with z, use ASCII codepoint directly
+        // after z as the default upper bound
+        this.lastStudent = "{";
         this.moduleOptions = {
             "brace_style_module": brace_style_module.getDefaultOptions(),
             "grade_server_module": grade_server_module.getDefaultOptions(),
@@ -83,7 +85,9 @@ function saveOptions() {
         // so the field will default to "a". Conveniently, this also means firstStudent
         // can't be the empty string since that's also falsey.
         options.firstStudent = options.firstStudent?.trim() || "a";
-        options.lastStudent = options.lastStudent?.trim() || "z";
+        // To include directory IDs that start with z, use ASCII codepoint directly
+        // after z as the default upper bound
+        options.lastStudent = options.lastStudent?.trim() || "{";
         if (options.firstStudent > options.lastStudent) {
             const tmp = options.firstStudent;
             options.firstStudent = options.lastStudent;

--- a/options.js
+++ b/options.js
@@ -78,6 +78,10 @@ function saveOptions() {
             options.lateScoreAdjustment = 0;
             needsReload = true;
         }
+        if (options.students.trim() !== options.students) {
+            options.students = options.students.trim();
+            needsReload = true;
+        }
         chrome.storage.sync.set(
             options
             , function () {

--- a/options.js
+++ b/options.js
@@ -36,7 +36,8 @@ class Options {
         this.submitServerAssignmentName = submitServerAssignmentName;
         this.filesToCheck = filesToCheck;
         this.lateScoreAdjustment = -12;
-        this.students = "*";
+        this.firstStudent = "a";
+        this.lastStudent = "z";
         this.moduleOptions = {
             "brace_style_module": brace_style_module.getDefaultOptions(),
             "grade_server_module": grade_server_module.getDefaultOptions(),
@@ -70,21 +71,28 @@ function restoreOptions(callback) {
 
 // Saves options to chrome.storage
 function saveOptions() {
-    let needsReload = false;
     try {
-        let options = JSON.parse(document.getElementById("optionsTextArea").value);
+        const optionsStr = document.getElementById("optionsTextArea").value;
+        let options = JSON.parse(optionsStr);
         if (options.lateScoreAdjustment > 0) {
             alert("Late score adjustment has to be negative. Defaulting the value to 0.");
             options.lateScoreAdjustment = 0;
-            needsReload = true;
         }
-        if (options.students.trim() !== options.students) {
-            options.students = options.students.trim();
-            needsReload = true;
+
+        // If firstStudent isn't a valid field, trim will produce undefined (falsey)
+        // so the field will default to "a". Conveniently, this also means firstStudent
+        // can't be the empty string since that's also falsey.
+        options.firstStudent = options.firstStudent?.trim() || "a";
+        options.lastStudent = options.lastStudent?.trim() || "z";
+        if (options.firstStudent > options.lastStudent) {
+            const tmp = options.firstStudent;
+            options.firstStudent = options.lastStudent;
+            options.lastStudent = tmp;
         }
+
         chrome.storage.sync.set(
-            options
-            , function () {
+            options,
+            function () {
                 // Update status to let user know options were saved.
                 let status = document.getElementById('status');
                 status.textContent = 'Options saved.';
@@ -92,6 +100,10 @@ function saveOptions() {
                     status.textContent = '';
                 }, 750);
             });
+
+        if (optionsStr !== JSON.stringify(options)) {
+            restoreOptionsLocal();
+        }
     } catch (error) {
         if (error instanceof SyntaxError) {
             let status = document.getElementById('status');
@@ -108,9 +120,6 @@ function saveOptions() {
             }, 3000);
             throw error;
         }
-    }
-    if (needsReload) {
-        restoreOptionsLocal();
     }
 }
 

--- a/submit_server_main.js
+++ b/submit_server_main.js
@@ -13,13 +13,16 @@ function main(options) {
     // add 'review' buttons next to last submission date for directly going to review page
     if (location.href.indexOf('instructor') > -1) {
         let tableSubmissions = $("table:contains('last submission')");
+        let acctColumn = $(tableSubmissions).find("tr").find("td:nth-child(3)");
         let onTimeColumn = $(tableSubmissions).find("tr").find("td:nth-child(8)");
         let lateColumn = $(tableSubmissions).find("tr").find("td:nth-child(9)");
         // let projectIndex = location.href.search(/projectPK=(\d+)/);
         for (let iStudent = 0; iStudent < onTimeColumn.length; iStudent++) {
             let onTimeTableCell = onTimeColumn[iStudent];
             let lateTableCell = lateColumn[iStudent];
-            if (hasSubmissionInOverviewTableCell(onTimeTableCell) || hasSubmissionInOverviewTableCell(lateTableCell)) {
+            let acctTableCell = acctColumn[iStudent];
+            if (isMemberOfStudentSet(acctTableCell, options.students)
+                && (hasSubmissionInOverviewTableCell(onTimeTableCell) || hasSubmissionInOverviewTableCell(lateTableCell))) {
                 let onTimeAutomaticTestScore = getAutomaticTestsScoreFromOverviewTableCell(onTimeTableCell);
                 let lateAutomaticTestScoreWithAdjustment =
                     getAutomaticTestsScoreFromOverviewTableCell(lateTableCell) + options.lateScoreAdjustment;

--- a/submit_server_main.js
+++ b/submit_server_main.js
@@ -21,7 +21,7 @@ function main(options) {
             let onTimeTableCell = onTimeColumn[iStudent];
             let lateTableCell = lateColumn[iStudent];
             let acctTableCell = acctColumn[iStudent];
-            if (isMemberOfStudentSet(acctTableCell, options.students)
+            if (isMemberOfStudentSet(acctTableCell, options.firstStudent, options.lastStudent)
                 && (hasSubmissionInOverviewTableCell(onTimeTableCell) || hasSubmissionInOverviewTableCell(lateTableCell))) {
                 let onTimeAutomaticTestScore = getAutomaticTestsScoreFromOverviewTableCell(onTimeTableCell);
                 let lateAutomaticTestScoreWithAdjustment =

--- a/submit_server_ui.js
+++ b/submit_server_ui.js
@@ -52,7 +52,6 @@ function getAutomaticTestsScoreFromOverviewTableCell(overviewTableCell) {
  */
 function isMemberOfStudentSet(acctTableCell, studentStr) {
     const acct = $(acctTableCell).find("a")[0].innerText; // hopefully this never fails :)
-    studentStr = studentStr.trim();
 
     if (studentStr === "*") return true;
     if (studentStr[0] === "(" && studentStr[studentStr.length - 1] === ")") {

--- a/submit_server_ui.js
+++ b/submit_server_ui.js
@@ -2,7 +2,6 @@
 * Copyright 2020 Gregory Kramida
 * */
 
-
 function hasSubmissionInOverviewTableCell(overviewTableCell) {
     return $(overviewTableCell).find("a")[0] !== undefined;
 }
@@ -38,6 +37,31 @@ function getAutomaticTestsScoreFromOverviewTableCell(overviewTableCell) {
         }
     }
     return score;
+}
+
+/**
+ * A hack :)
+ *
+ * if students is *, then return true
+ * if students is a pair, specified with parens, treat as inclusive endpoint range
+ * otherwise, treat as set/list and use contains
+ *
+ * @param {HTMLTableCellElement} acctTableCell
+ * @param {String} studentStr
+ * @returns {boolean} whether the student is a member of the student set
+ */
+function isMemberOfStudentSet(acctTableCell, studentStr) {
+    const acct = $(acctTableCell).find("a")[0].innerText; // hopefully this never fails :)
+
+    if (studentStr === "*") return true;
+    if (studentStr[0] === "(" && studentStr[studentStr.length - 1] === ")") {
+        const studentBounds = studentStr.substring(1, studentStr.length - 1).split(",");
+        const start = studentBounds[0].trim();
+        const end = studentBounds[1].trim();
+        return acct >= start && acct <= end;
+    }
+    const students = studentStr.split(",").map(str => str.trim());
+    return students.includes(acct);
 }
 
 /**

--- a/submit_server_ui.js
+++ b/submit_server_ui.js
@@ -52,13 +52,15 @@ function getAutomaticTestsScoreFromOverviewTableCell(overviewTableCell) {
  */
 function isMemberOfStudentSet(acctTableCell, studentStr) {
     const acct = $(acctTableCell).find("a")[0].innerText; // hopefully this never fails :)
+    studentStr = studentStr.trim();
 
     if (studentStr === "*") return true;
     if (studentStr[0] === "(" && studentStr[studentStr.length - 1] === ")") {
-        const studentBounds = studentStr.substring(1, studentStr.length - 1).split(",");
-        const start = studentBounds[0].trim();
-        const end = studentBounds[1].trim();
-        return acct >= start && acct <= end;
+        const studentBounds = studentStr
+            .substring(1, studentStr.length - 1)
+            .split(",")
+            .map(str => str.trim());
+        return acct >= studentBounds[0] && acct <= studentBounds[1];
     }
     const students = studentStr.split(",").map(str => str.trim());
     return students.includes(acct);

--- a/submit_server_ui.js
+++ b/submit_server_ui.js
@@ -40,29 +40,18 @@ function getAutomaticTestsScoreFromOverviewTableCell(overviewTableCell) {
 }
 
 /**
- * A hack :)
- *
- * if students is *, then return true
- * if students is a pair, specified with parens, treat as inclusive endpoint range
- * otherwise, treat as set/list and use contains
- *
+ * Check whether student in acctTableCell is between first & last student bounds
  * @param {HTMLTableCellElement} acctTableCell
- * @param {String} studentStr
+ * @param {String} firstStudent
+ * @param {String} lastStudent
  * @returns {boolean} whether the student is a member of the student set
  */
-function isMemberOfStudentSet(acctTableCell, studentStr) {
+function isMemberOfStudentSet(acctTableCell, firstStudent, lastStudent) {
     const acct = $(acctTableCell).find("a")[0].innerText; // hopefully this never fails :)
 
-    if (studentStr === "*") return true;
-    if (studentStr[0] === "(" && studentStr[studentStr.length - 1] === ")") {
-        const studentBounds = studentStr
-            .substring(1, studentStr.length - 1)
-            .split(",")
-            .map(str => str.trim());
-        return acct >= studentBounds[0] && acct <= studentBounds[1];
-    }
-    const students = studentStr.split(",").map(str => str.trim());
-    return students.includes(acct);
+    // Supposedly, JS string comparison can have "interesting" behavior depending on locale
+    // But this might not matter since directory IDs *shouldn't* be anything other than /[a-z][a-z0-9]{,7}/
+    return acct >= firstStudent && acct <= lastStudent;
 }
 
 /**


### PR DESCRIPTION
Show only students that are specified in configuration json

On submit server, only show REVIEW link if student is a member of set of students specified in configuration json. Use "*" for students key to specify all students; otherwise specify comma separated list (no brackets) or use a two comma separated values surrounded by parentheses to specify a range with inclusive bounds.