### PR TITLE
Use different error message when student doesn't exist

### DIFF
--- a/grades_server_main.js
+++ b/grades_server_main.js
@@ -80,6 +80,10 @@ function addListenerForOpeningStudentGradePage() {
                 let studentTableRow = $("form[action=\"enterGrades.cgi\"]>table>tbody>tr:has(td:contains('" + report.directoryId + "'))");
                 let headersTableCell = $("form[action=\"enterGrades.cgi\"]>table>tbody>tr:first td");
 
+                if (studentTableRow.length === 0) {
+                    alert("Error: No student with that directory ID found (student may have dropped or withdrawn from the course)");
+                    return;
+                }
                 if (studentTableRow.length !== 1) {
                     alert("Error: More than one student with that directory ID found");
                     return;


### PR DESCRIPTION
Report that a student doesn't exist in the grade server instead of reporting that a directory ID occurs multiple times. Provides suggestion as to possible reason for error. 

Addresses #79 

Appears to work correctly on `rshort`