### PR TITLE
Prevent text from displaying under codegrader panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -206,3 +206,7 @@
 a:visited {
 	color:#666 !important ;
 }
+
+body > div:nth-child(5) {
+    margin-right: 450px;
+}


### PR DESCRIPTION
Shrink the size of the `div` containing the review page contents by increasing its margin to the same as the width of the codegrader panel. This way, the main contents of the page and codegrader ui panel can't overlap. 

Before (certain page content appears underneath codegrader ui panel and cannot be interacted with):
![image](https://user-images.githubusercontent.com/11336005/113031669-fba75b80-915c-11eb-85f7-64d2b15a9cc2.png)

After (page content reflows so it can be interacted with):
![image](https://user-images.githubusercontent.com/11336005/113032130-7e301b00-915d-11eb-843b-9ef78fc70fc8.png)

This is the minimal effort solution to #92. Selecting the `div` via `nth-child(5)` is pretty hacky and subject to breaking if the submit server review page changes (the `div` has neither id nor class). I'm not sure that it should be a permanent solution. 

For example, even if CodeGrader is inactive for the project but is an activated extension, the CSS rule still applies and causes the main content of the page to fail to occupy the full width of the page.

![image](https://user-images.githubusercontent.com/11336005/113031233-715ef780-915c-11eb-8108-f6954d4f523d.png)
