### PR TITLE
Prevent text from displaying under codegrader panel 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -206,3 +206,7 @@
 a:visited {
 	color:#666 !important ;
 }
+
+body > div:nth-child(5) {
+    margin-right: 450px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -206,7 +206,3 @@
 a:visited {
 	color:#666 !important ;
 }
-
-body > div:nth-child(5) {
-    margin-right: 450px;
-}

--- a/submit_server_main.js
+++ b/submit_server_main.js
@@ -103,6 +103,14 @@ function constructUiPanel(options, filePaths) {
     uiPanelContainer.appendChild(uiPanel);
     document.body.appendChild(uiPanelContainer);
 
+    // set margin-right of div containing page content so it doesn't overlap with the ui panel
+    document.body.querySelectorAll("body > div")[2].style.setProperty(
+        "margin-right",
+        // This gets the actual, computed width of the ui-panel so that the ui panel and primary
+        // page content exactly line up with each other without gap or overlap.
+        window.getComputedStyle(uiPanelContainer).width
+    );
+
     makeCodeFeedArrow();
 
     if (filePaths.length === 0) {

--- a/submit_server_main.js
+++ b/submit_server_main.js
@@ -106,8 +106,6 @@ function constructUiPanel(options, filePaths) {
     // set margin-right of div containing page content so it doesn't overlap with the ui panel
     document.body.querySelectorAll("body > div")[2].style.setProperty(
         "margin-right",
-        // This gets the actual, computed width of the ui-panel so that the ui panel and primary
-        // page content exactly line up with each other without gap or overlap.
         window.getComputedStyle(uiPanelContainer).width
     );
 


### PR DESCRIPTION
This is the minimal effort solution to #92.  Shrink the size of the `div` containing the review page contents by increasing its margin to the same as the width of the codegrader panel. This way, the main contents of the page and codegrader ui panel can't overlap. 

Before (certain page content appears underneath codegrader ui panel and cannot be interacted with):
![image](https://user-images.githubusercontent.com/11336005/113031669-fba75b80-915c-11eb-85f7-64d2b15a9cc2.png)

After (page content reflows so it can be interacted with):
![image](https://user-images.githubusercontent.com/11336005/113032130-7e301b00-915d-11eb-843b-9ef78fc70fc8.png)

Selecting the 3rd child `div` of body is pretty hacky and subject to breaking if the submit server review page changes (the `div` has neither id nor class to make selection easier). I'm not sure that it should be a permanent solution. 