### PR TITLE
Small issue with lambda expressions

### DIFF
--- a/code_analysis/code_entity_search.js
+++ b/code_analysis/code_entity_search.js
@@ -265,6 +265,9 @@
                 }
                 break;
             case "LambdaExpression":
+                scope.setNextBatchOfChildAstNodes([astNode.body]);
+                continueProcessingCurrentScope();
+                break;
             case "CatchClause":
                 scope.setNextBatchOfChildAstNodes(astNode.body.statements);
                 continueProcessingCurrentScope();


### PR DESCRIPTION
Apparently the parser names attributes the same thing but makes them completely different objects...

This fixes the lambda expression handling in code analysis.