### PR TITLE
Instanceof support for spacing module

### DIFF
--- a/code_analysis/code_entity_search.js
+++ b/code_analysis/code_entity_search.js
@@ -377,6 +377,8 @@
                 break;
             case "InfixExpression":
                 return this.getOperandStart(operandAstNode.leftOperand);
+            case "SimpleType":
+                return operandAstNode.name.location.start;
             default:
                 return operandAstNode.location.start;
         }

--- a/modules/spacing_module.js
+++ b/modules/spacing_module.js
@@ -51,6 +51,11 @@ let spacing_module = {};
                     let rightHandSide;
                     let operator;
                     switch (expression.node) {
+                        case "InstanceofExpression":
+                            leftHandSide = expression.leftOperand;
+                            rightHandSide = expression.rightOperand;
+                            operator = "instanceof";
+                            break;
                         case "InfixExpression":
                             leftHandSide = expression.leftOperand;
                             rightHandSide = expression.rightOperand;
@@ -67,7 +72,6 @@ let spacing_module = {};
                             operator = "=";
                             break;
                     }
-
 
                     const textBetweenOperandsStart = code_analysis.getOperandEnd(leftHandSide);
                     //TODO: from code design perspective, these corrections should also be inside the getOperandEnd/getOperandStart functions, not here


### PR DESCRIPTION
As Will found on Slack, Proj 2 Fall 2020's oadkins used instanceof with the spacing module which broke it. This fixes it by adding support for this expression type.