### PR TITLE
Feature#125 code entities test module

### DIFF
--- a/code_analysis/code_entity.js
+++ b/code_analysis/code_entity.js
@@ -40,6 +40,14 @@ class CodeEntity {
      * @return {string}
      * @protected
      */
+    get _toolTip(){
+        return "No problems were automatically detected."
+    }
+
+    /**
+     * @return {string}
+     * @protected
+     */
     get _tagName(){
         throw ("tagName property getter for any subclass of " + CodeEntity.constructor.name + " should be overridden.");
     }
@@ -50,14 +58,6 @@ class CodeEntity {
      */
     get _defaultMessageText(){
         return "";
-    }
-
-    /**
-     * @return {string}
-     * @protected
-     */
-    get _toolTip(){
-        return "No problems were automatically detected."
     }
 
     /** @return {string} hex color for the tag

--- a/modules/test_module.js
+++ b/modules/test_module.js
@@ -28,6 +28,59 @@ let test_module = {};
         return new Options();
     }
 
+    const moduleColor = "#92b9d1";
+
+    class TestMethodUsage extends CodeEntity {
+        #declaration
+        #message
+
+        /**
+         *
+         * @param {HTMLTableRowElement} trCodeLine
+         * @param {Declaration} declaration
+         */
+        constructor(trCodeLine, declaration) {
+            super(trCodeLine);
+            this.#declaration = declaration;
+            //__DEBUG
+            console.log(declaration.declarationType, UsageTypeByDeclarationType.get(declaration.declarationType))
+            this.#message = "Unused " + UsageTypeByDeclarationType.get(declaration.declarationType)
+                + ": \"" + declaration.name + "\".";
+        }
+
+        get points(){
+            return -1;
+        }
+
+        get isIssue(){
+            return true;
+        }
+
+        get _labelStyleClass(){
+            return LabelClassByDeclarationType.get(this.#declaration.declarationType);
+        }
+
+        get _labelName(){
+            return this.#declaration.name;
+        }
+
+        get _tagName(){
+            return "\"" + this.#declaration.name + "\" unused."
+        }
+
+        get _defaultMessageText(){
+            return this.#message;
+        }
+
+        get _toolTip(){
+            return this.#message;
+        }
+
+        get _tagColor(){
+            return moduleColor;
+        }
+    }
+
     /**
      * Initialize the module: perform code analysis, add relevant controls to the uiPanel, add highlights and
      * buttons in the code.
@@ -36,7 +89,7 @@ let test_module = {};
      * @param {Map.<string,CodeFile>} codeFileDictionary
      * @param {Options} options
      */
-    this.initialize = function (uiPanel, codeFileDictionary, options) {
+    this.initialize2 = function (uiPanel, codeFileDictionary, options) {
         if (!options.enabled || codeFileDictionary.size === 0) {
             return;
         }

--- a/modules/test_module.js
+++ b/modules/test_module.js
@@ -99,7 +99,64 @@ let test_module = {};
     }
 
     class UntestedMethod extends CodeEntity{
+        #shortMethodName;
+        static #testScopeStartTrCodeLine;
+        static #methodNames = [];
+        /**
+         * @param {HTMLTableRowElement} trCodeLine
+         * @param {string} methodName
+         */
+        constructor( trCodeLine, methodName) {
+            super(trCodeLine);
 
+            UntestedMethod.#testScopeStartTrCodeLine = trCodeLine;
+            let shortName = methodName;
+            const parts = methodName.split('.')
+            if (parts.length > 1) {
+                shortName = parts[1];
+            }
+            UntestedMethod.#methodNames.push(shortName);
+            this.#shortMethodName = shortName;
+        }
+
+        get points(){
+            return -1;
+        }
+
+        /** @return {boolean} */
+        get isIssue(){
+            return true;
+        }
+
+        get _labelName(){
+            throw ("labelName property getter for any subclass of " + CodeEntity.constructor.name + " should be overridden.");
+        }
+
+        get _labelStyleClass(){
+            return "untested-method-problem";
+        }
+
+        get _toolTip(){
+            return "The method/constructor '" + this.#shortMethodName + "' has not been tested.";
+        }
+
+        /**
+         * @override
+         */
+        addAsCodeTagWithDefaultComment(){
+            throw ("Untested methods can't have individual tags. Use the `addTagForAllUnusedTests` static method instead.");
+        }
+
+        static addTagForAllUnusedTests(){
+            let message = "Constructors/methods " + UntestedMethod.#methodNames.join(", ") + " do not appear to be tested.";
+
+            addCodeTagWithComment(
+                UntestedMethod.#testScopeStartTrCodeLine,
+                "Generate untested code summary",
+                message,
+                badTestColor
+            );
+        }
     }
 
     /**
@@ -185,11 +242,7 @@ let test_module = {};
                 codeFileToPlaceLackOfTestLabels = parsedCodeFiles[0];
             }
             const trCodeLine = codeFileToPlaceLackOfTestLabels.trCodeLines[0];
-            let shortName = untestedMethod;
-            const parts = untestedMethod.split('.')
-            if (parts.length > 1) {
-                shortName = parts[1];
-            }
+
             $(uiPanel).append(makeLabelWithClickToScroll(untestedMethod, trCodeLine, "untested-method-problem", "The method/constructor '" + shortName + "' has not been tested."));
             //TODO: not sure this needs to be done.
             // addCodeTagWithComment(trCodeLine, "Method was not tested: " + call.name,

--- a/modules/test_module.js
+++ b/modules/test_module.js
@@ -28,57 +28,78 @@ let test_module = {};
         return new Options();
     }
 
-    const moduleColor = "#92b9d1";
+    const moduleColor = "#7c9318";
+    const badTestColor = "#7c3518";
 
     class TestMethodUsage extends CodeEntity {
-        #declaration
-        #message
+        #call;
+        #message;
+        #toolTip;
+        #tagName;
+        #color;
 
         /**
          *
          * @param {HTMLTableRowElement} trCodeLine
-         * @param {Declaration} declaration
+         * @param {MethodCall} call
+         * @param {boolean} inAnnotatedTest
          */
-        constructor(trCodeLine, declaration) {
+        constructor(trCodeLine, call, inAnnotatedTest) {
             super(trCodeLine);
-            this.#declaration = declaration;
-            //__DEBUG
-            console.log(declaration.declarationType, UsageTypeByDeclarationType.get(declaration.declarationType))
-            this.#message = "Unused " + UsageTypeByDeclarationType.get(declaration.declarationType)
-                + ": \"" + declaration.name + "\".";
+            this.#call = call;
+
+            this.#message = "The " + call.callType + " '" + call.name + "' is not tested correctly.";
+            let locationDescription;
+            let testAdjective;
+            if(inAnnotatedTest){
+                locationDescription = "test code (click to scroll).";
+                testAdjective = "";
+                this.#color = moduleColor;
+            }else{
+                locationDescription = "code without @Test annotation (click to scroll)";
+                testAdjective = " unannotated";
+                this.#color = badTestColor;
+            }
+            this.#toolTip = "The " + call.callType + " '" + call.name + "' appears in " + locationDescription;
+            this.#tagName = capitalize(call.callType) + " call from" + testAdjective + " test: " + call.name;
+
         }
 
-        get points(){
+        get points() {
             return -1;
         }
 
-        get isIssue(){
+        get isIssue() {
             return true;
         }
 
-        get _labelStyleClass(){
-            return LabelClassByDeclarationType.get(this.#declaration.declarationType);
+        get _labelStyleClass() {
+            return "";
         }
 
-        get _labelName(){
-            return this.#declaration.name;
+        get _labelName() {
+            return this.#call.name;
         }
 
-        get _tagName(){
-            return "\"" + this.#declaration.name + "\" unused."
+        get _tagName() {
+            return this.#tagName;
         }
 
-        get _defaultMessageText(){
+        get _defaultMessageText() {
             return this.#message;
         }
 
-        get _toolTip(){
-            return this.#message;
+        get _toolTip() {
+            return this.#toolTip
         }
 
-        get _tagColor(){
-            return moduleColor;
+        get _tagColor() {
+            return this.#color;
         }
+    }
+
+    class UntestedMethod extends CodeEntity{
+
     }
 
     /**
@@ -103,7 +124,7 @@ let test_module = {};
                 continue;
             }
             parsedCodeFiles.push(codeFile);
-            if(codeFile.filename.includes('StudentTests.java')) {
+            if (codeFile.filename.includes('StudentTests.java')) {
                 codeFileToPlaceLackOfTestLabels = codeFile;
             }
             for (const typeInformation of codeFile.types.values()) {
@@ -114,7 +135,7 @@ let test_module = {};
                 }
                 const testedMethods = searchScopes(methodsExpectedToBeTestedSet, testScopes, typeInformation);
 
-                for(const call of testedMethods) {
+                for (const call of testedMethods) {
                     const trCodeLine = codeFile.trCodeLines[call.astNode.location.start.line - 1];
 
                     if (call.callType === MethodCallType.CONSTRUCTOR) {
@@ -130,7 +151,7 @@ let test_module = {};
             }
         }
 
-        if(codeFileToPlaceLackOfTestLabels != null) {
+        if (codeFileToPlaceLackOfTestLabels != null) {
             // Check all other methods in the test file. If the other methods test something not yet tested, it is most
             // likely an issue of missing "@Test". Note helper methods won't be hit by this, as they are tested already.
             for (const typeInformation of codeFileToPlaceLackOfTestLabels.types.values()) {
@@ -158,6 +179,7 @@ let test_module = {};
         if (parsedCodeFiles.length === 0) {
             return;
         }
+
         for (const untestedMethod of methodsExpectedToBeTestedSet) {
             if (codeFileToPlaceLackOfTestLabels === null) {
                 codeFileToPlaceLackOfTestLabels = parsedCodeFiles[0];
@@ -168,7 +190,7 @@ let test_module = {};
             if (parts.length > 1) {
                 shortName = parts[1];
             }
-            $(uiPanel).append(makeLabelWithClickToScroll(untestedMethod, trCodeLine, "untested-method-problem", "The method '" + shortName + "' has not been tested."));
+            $(uiPanel).append(makeLabelWithClickToScroll(untestedMethod, trCodeLine, "untested-method-problem", "The method/constructor '" + shortName + "' has not been tested."));
             //TODO: not sure this needs to be done.
             // addCodeTagWithComment(trCodeLine, "Method was not tested: " + call.name,
             //     "The method '" + shortName + "' does not appear in tests.", "#7c9318");
@@ -189,17 +211,17 @@ let test_module = {};
         for (const scope of testScopes) {
             for (const call of scope.methodCalls) {
                 // If the method is from the tests class, check its calls
-                if(call.name.substring(0, 5) === "this.") {
+                if (call.name.substring(0, 5) === "this.") {
                     let testedMethodValues = searchScopes(untestedMethods, typeInformation.scopes.filter(scope1 => scope1.astNode.hasOwnProperty("name") && scope1.astNode.name.identifier === call.methodName), typeInformation);
                     testedMethodValues.forEach(call => testedMethods.add(call));
                 }
 
-                if(untestedMethods.has(call.name)) {
+                if (untestedMethods.has(call.name)) {
                     testedMethods.add(call);
                     untestedMethods.delete(call.name);
                 }
-                // If a static method is called from a non-static reference, it appears as
-                // $ClassName$.methodName when we look for ClassName.methodName.
+                    // If a static method is called from a non-static reference, it appears as
+                    // $ClassName$.methodName when we look for ClassName.methodName.
                 // However, the $'s stay if it is tested, so this is not a perfect solution.
                 else if (untestedMethods.has(call.name.replaceAll("$", ""))) {
                     testedMethods.add(call);

--- a/modules/test_module.js
+++ b/modules/test_module.js
@@ -51,11 +51,11 @@ let test_module = {};
             this.#message = "The " + call.callType + " '" + call.name + "' is not tested correctly.";
             let locationDescription;
             let testAdjective;
-            if(inAnnotatedTest){
+            if (inAnnotatedTest) {
                 locationDescription = "test code (click to scroll).";
                 testAdjective = "";
                 this.#color = moduleColor;
-            }else{
+            } else {
                 locationDescription = "code without @Test annotation (click to scroll)";
                 testAdjective = " unannotated";
                 this.#color = badTestColor;
@@ -98,15 +98,16 @@ let test_module = {};
         }
     }
 
-    class UntestedMethod extends CodeEntity{
+    class UntestedMethod extends CodeEntity {
         #shortMethodName;
         static #testScopeStartTrCodeLine;
         static #methodNames = [];
+
         /**
          * @param {HTMLTableRowElement} trCodeLine
          * @param {string} methodName
          */
-        constructor( trCodeLine, methodName) {
+        constructor(trCodeLine, methodName) {
             super(trCodeLine);
 
             UntestedMethod.#testScopeStartTrCodeLine = trCodeLine;
@@ -119,35 +120,35 @@ let test_module = {};
             this.#shortMethodName = shortName;
         }
 
-        get points(){
+        get points() {
             return -1;
         }
 
         /** @return {boolean} */
-        get isIssue(){
+        get isIssue() {
             return true;
         }
 
-        get _labelName(){
+        get _labelName() {
             throw ("labelName property getter for any subclass of " + CodeEntity.constructor.name + " should be overridden.");
         }
 
-        get _labelStyleClass(){
+        get _labelStyleClass() {
             return "untested-method-problem";
         }
 
-        get _toolTip(){
+        get _toolTip() {
             return "The method/constructor '" + this.#shortMethodName + "' has not been tested.";
         }
 
         /**
          * @override
          */
-        addAsCodeTagWithDefaultComment(){
+        addAsCodeTagWithDefaultComment() {
             throw ("Untested methods can't have individual tags. Use the `addTagForAllUnusedTests` static method instead.");
         }
 
-        static addTagForAllUnusedTests(){
+        static addTagForAllUnusedTests() {
             let message = "Constructors/methods " + UntestedMethod.#methodNames.join(", ") + " do not appear to be tested.";
 
             addCodeTagWithComment(
@@ -159,20 +160,36 @@ let test_module = {};
         }
     }
 
+    let initialized = false;
+
     /**
-     * Initialize the module: perform code analysis, add relevant controls to the uiPanel, add highlights and
-     * buttons in the code.
-     *
-     * @param {HTMLDivElement} uiPanel main panel where to add controls
-     * @param {Map.<string,CodeFile>} codeFileDictionary
-     * @param {Options} options
+     * Initialize the module
+     * @param {{moduleOptions : {test_module: Options}}} global_options
      */
-    this.initialize2 = function (uiPanel, codeFileDictionary, options) {
-        if (!options.enabled || codeFileDictionary.size === 0) {
+    this.initialize = function (global_options) {
+        this.options = global_options.moduleOptions.test_module;
+
+        if (!this.options.enabled) {
             return;
         }
-        $(uiPanel).append("<h3 style='color:#7c9318'>Method Tests</h3>");
-        let methodsExpectedToBeTestedSet = new Set(options.methodsExpectedToBeTested);
+        /** @type {Array.<TestMethodUsage>} */
+        this.testCodeOccurences = [];
+        /** @type {Array.<TestMethodUsage>} */
+        this.unannotatedTestCodeOccurences = [];
+        /** @type {Array.<UntestedMethod>} */
+        this.untestedMethods = [];
+        initialized = true;
+    }
+
+    /**
+     * Perform code analysis & discover code entities of interest
+     * @param {Map.<string, CodeFile>} codeFileDictionary
+     */
+    this.processCode = function (codeFileDictionary) {
+        if (!this.options.enabled) {
+            return;
+        }
+        let methodsExpectedToBeTestedSet = new Set(this.options.methodsExpectedToBeTested);
         let codeFileToPlaceLackOfTestLabels = null;
         let parsedCodeFiles = [];
 
@@ -194,16 +211,7 @@ let test_module = {};
 
                 for (const call of testedMethods) {
                     const trCodeLine = codeFile.trCodeLines[call.astNode.location.start.line - 1];
-
-                    if (call.callType === MethodCallType.CONSTRUCTOR) {
-                        $(uiPanel).append(makeLabelWithClickToScroll(call.name, trCodeLine, "", "The constructor '" + call.name + "' appears in test code (click to scroll)."));
-                        addCodeTagWithComment(trCodeLine, "Constructor call from test: " + call.name,
-                            "The constructor '" + call.name + "' is not tested correctly.", "#7c9318");
-                    } else {
-                        $(uiPanel).append(makeLabelWithClickToScroll(call.name, trCodeLine, "", "The method '" + call.astNode.name.identifier + "' appears in test code (click to scroll)."));
-                        addCodeTagWithComment(trCodeLine, "Method call from test: " + call.name,
-                            "The method '" + call.astNode.name.identifier + "' is not tested correctly.", "#7c9318");
-                    }
+                    this.testCodeOccurences.push(new TestMethodUsage(trCodeLine, call, true));
                 }
             }
         }
@@ -213,22 +221,13 @@ let test_module = {};
             // likely an issue of missing "@Test". Note helper methods won't be hit by this, as they are tested already.
             for (const typeInformation of codeFileToPlaceLackOfTestLabels.types.values()) {
                 /** @type {Array.<Scope>} */
-                const semiTestScopes = typeInformation.scopes.filter(scope => !scope.isTest);
+                const unannotatedTestScopes = typeInformation.scopes.filter(scope => !scope.isTest);
 
-                const semiTestedMethods = searchScopes(methodsExpectedToBeTestedSet, semiTestScopes, typeInformation);
+                const unannotatedTestedMethods = searchScopes(methodsExpectedToBeTestedSet, unannotatedTestScopes, typeInformation);
 
-                for (const call of semiTestedMethods) {
+                for (const call of unannotatedTestedMethods) {
                     const trCodeLine = codeFileToPlaceLackOfTestLabels.trCodeLines[call.astNode.location.start.line - 1];
-
-                    if (call.callType === MethodCallType.CONSTRUCTOR) {
-                        $(uiPanel).append(makeLabelWithClickToScroll(call.name, trCodeLine, "", "The constructor '" + call.name + "' appears in code without @Test (click to scroll)."));
-                        addCodeTagWithComment(trCodeLine, "Constructor call from method without annotation: " + call.name,
-                            "The constructor '" + call.name + "' is not tested correctly.", "#7c3518");
-                    } else {
-                        $(uiPanel).append(makeLabelWithClickToScroll(call.name, trCodeLine, "", "The method '" + call.astNode.name.identifier + "' appears in code without @Test (click to scroll)."));
-                        addCodeTagWithComment(trCodeLine, "Method call from method without annotation: " + call.name,
-                            "The method '" + call.astNode.name.identifier + "' is not tested correctly.", "#7c3518");
-                    }
+                    this.testCodeOccurences.push(new TestMethodUsage(trCodeLine, call, false));
                 }
             }
         }
@@ -237,17 +236,50 @@ let test_module = {};
             return;
         }
 
-        for (const untestedMethod of methodsExpectedToBeTestedSet) {
+        for (const untestedMethodQualifiedName of methodsExpectedToBeTestedSet) {
             if (codeFileToPlaceLackOfTestLabels === null) {
                 codeFileToPlaceLackOfTestLabels = parsedCodeFiles[0];
             }
             const trCodeLine = codeFileToPlaceLackOfTestLabels.trCodeLines[0];
-
-            $(uiPanel).append(makeLabelWithClickToScroll(untestedMethod, trCodeLine, "untested-method-problem", "The method/constructor '" + shortName + "' has not been tested."));
-            //TODO: not sure this needs to be done.
-            // addCodeTagWithComment(trCodeLine, "Method was not tested: " + call.name,
-            //     "The method '" + shortName + "' does not appear in tests.", "#7c9318");
+            this.untestedMethods.push(new UntestedMethod(trCodeLine, untestedMethodQualifiedName));
         }
+    }
+
+    /**
+     * Add all information collected so far by the module to the UI panel.
+     * @param {HTMLDivElement} uiPanel
+     */
+    this.addInfoToUiPanel = function (uiPanel) {
+        if (!this.options.enabled) {
+            return;
+        }
+        $(uiPanel).append("<h3 style='color:" + moduleColor + "'>Student Tests</h3>");
+        for (const testedMethodCall of this.testCodeOccurences) {
+            testedMethodCall.addAsLabelToPanel(uiPanel);
+            testedMethodCall.addAsCodeTagWithDefaultComment();
+        }
+        for (const testedMethodCall of this.unannotatedTestCodeOccurences) {
+            testedMethodCall.addAsLabelToPanel(uiPanel);
+            testedMethodCall.addAsCodeTagWithDefaultComment();
+        }
+        for (const untestedMethod of this.untestedMethods) {
+            untestedMethod.addAsLabelToPanel(uiPanel);
+        }
+        UntestedMethod.addTagForAllUnusedTests();
+    }
+
+    /**
+     * Return all CodeEntities thus far extracted from the code.
+     * @returns {Array.<CodeEntity>}
+     */
+    this.getCodeEntities = function () {
+        if (!this.options.enabled) {
+            return [];
+        }
+        if (!initialized) {
+            throw ("Module not initialized. Please call the initialize function first.");
+        }
+        return this.testCodeOccurences.concat(this.unannotatedTestCodeOccurences).concat(this.untestedMethods);
     }
 
     /**

--- a/modules/unused_code_module.js
+++ b/modules/unused_code_module.js
@@ -105,8 +105,6 @@ let unused_code_module = {};
         constructor(trCodeLine, declaration) {
             super(trCodeLine);
             this.#declaration = declaration;
-            //__DEBUG
-            console.log(declaration.declarationType, UsageTypeByDeclarationType.get(declaration.declarationType))
             this.#message = "Unused " + UsageTypeByDeclarationType.get(declaration.declarationType)
                 + ": \"" + declaration.name + "\".";
         }

--- a/sample_options/CMSC132/projects/P4_LinkedLists_CodeGrader_options.json5
+++ b/sample_options/CMSC132/projects/P4_LinkedLists_CodeGrader_options.json5
@@ -113,6 +113,6 @@
     submitServerAssignmentName: 'Proj 4',
     usageStatisticsOptions: {
         anonymizeUser: true,
-        enabled: false,
+        enabled: true,
     }
 }

--- a/submit_server_main.js
+++ b/submit_server_main.js
@@ -147,8 +147,9 @@ function constructUiPanel(options, filePaths) {
         unused_code_module.processCode(codeFileDictionary)
         unused_code_module.addInfoToUiPanel(uiPanel);
 
-        //TODO: CodeEntity overhaul
-        test_module.initialize(uiPanel, codeFileDictionary, options.moduleOptions.test_module);
+        test_module.initialize(options);
+        test_module.processCode(codeFileDictionary);
+        test_module.addInfoToUiPanel(uiPanel);
 
         indentation_module.initialize(options);
         indentation_module.processCode(codeFileDictionary);

--- a/utilities.js
+++ b/utilities.js
@@ -191,6 +191,18 @@ function getHelperMethodsUsedInCodeBlock(trCodeLines, helperMethods) {
 }
 
 /**
+ * Convert the legacy notation, e.g. SomeClass.staticMethod or $SomeClass$.instanceMethod to a method reference,
+ * e.g. SomeClass::someMethod
+ * @param {string} legacyNotationMethodName
+ * @return {string} resulting method reference (as a string).
+ */
+function legacyNotationToMethodReference(legacyNotationMethodName) {
+    const legacyPattern = /\$?(\w+)\$?[.](\w+)/;
+    const match = legacyNotationMethodName.match(legacyPattern);
+    return match[1] + "::" + match[2];
+}
+
+/**
  * Return a range of trCodeLines starting from line matching start regex (inclusive) and before
  * matching end regex (exclusive).
  * @param {Array.<HTMLTableRowElement>} trCodeLines


### PR DESCRIPTION
Overhaul of Test Module using CodeEntity classes for tested method occurrences, tested methods inside tests w/o @Test annotation, and untested methods.
The code also features improved label names & messaging (using  method reference notation that is true to form in Java instead of the home-grown $-delimited notation for instance methods).
One new tool is the capability to auto-generate the summary about all untested methods after the first line of the test module java file by clicking the tag made specifically for this purpose.