### PR TITLE
Fix #133 and extra indent module fix

### DIFF
--- a/code_analysis/code_component_search.js
+++ b/code_analysis/code_component_search.js
@@ -192,7 +192,7 @@
                 continueProcessingCurrentScope();
                 break;
             case "ConditionalExpression":
-                scope.setNextBatchOfChildAstNodes([astNode.expression, astNode.thenExpression]);
+                scope.setNextBatchOfChildAstNodes([astNode.expression, astNode.thenExpression, astNode.elseExpression]);
                 continueProcessingCurrentScope();
                 break;
             case "LabeledStatement":
@@ -296,6 +296,12 @@
                 scope.setNextBatchOfChildAstNodes(astNode.arguments);
                 continueProcessingCurrentScope();
                 break;
+            case "SimpleName":
+            case "ThisExpression":
+            case "SimpleType":
+            case "NumberLiteral":
+            case "StringLiteral":
+            case "NullLiteral":
             default:
                 break;
         }

--- a/modules/indentation_module.js
+++ b/modules/indentation_module.js
@@ -324,7 +324,7 @@ let indentation_module = {};
                         expectedIndent = currentIndentationWidth;
 
                     }
-                } else if (!isPrev && ([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) !== -1 && (isSwitch && codeText.trim().indexOf(":") !== -1))) {
+                } else if (isPrev && ([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) !== -1 && (isSwitch && codeText.trim().indexOf(":") !== -1))) {
                     if (isNotAllman === 0) {
                         isPrev = false;
                     }

--- a/modules/indentation_module.js
+++ b/modules/indentation_module.js
@@ -314,7 +314,7 @@ let indentation_module = {};
                         isPrev = true;
                         expectedIndent = currentIndentationWidth;
                     }
-                } else if (!isPrev && [";", "{", "}", ":"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1) {
+                } else if (!isPrev && ([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1 || (isSwitch && codeText.trim().indexOf(":") === -1))) {
                     if (codeText.trim().search(/^(private|public|protected)/) === -1 || // False negative - package private Allman
                         codeText.trim().charAt(codeText.trim().length - 1) !== ")") { // False positive - multiline fields ending in )
 
@@ -324,7 +324,7 @@ let indentation_module = {};
                         expectedIndent = currentIndentationWidth;
 
                     }
-                } else if (isPrev && [";", "{", "}", ":"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) !== -1) {
+                } else if (!isPrev && ([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) !== -1 && (isSwitch && codeText.trim().indexOf(":") !== -1))) {
                     if (isNotAllman === 0) {
                         isPrev = false;
                     }

--- a/modules/indentation_module.js
+++ b/modules/indentation_module.js
@@ -324,7 +324,7 @@ let indentation_module = {};
                         expectedIndent = currentIndentationWidth;
 
                     }
-                } else if (isPrev && ([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) !== -1 && (isSwitch && codeText.trim().indexOf(":") !== -1))) {
+                } else if (isPrev && !([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1 || (isSwitch && codeText.trim().indexOf(":") === -1))) {
                     if (isNotAllman === 0) {
                         isPrev = false;
                     }


### PR DESCRIPTION
Found the issue for #133 is that the component search does not get the elseExpression branch. Also, during this I saw that my code that checks if the code line is not yet complete (i.e., a line of code is on two lines) treats colon as an always correct line-ender, when it should only be correct when in a switch statement.