### PR TITLE
Matts branch

### DIFF
--- a/modules/indentation_module.js
+++ b/modules/indentation_module.js
@@ -328,7 +328,7 @@ let indentation_module = {};
                         isPrev = true;
                         expectedIndent = currentIndentationWidth;
                     }
-                } else if (!isPrev && ([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1 || (isSwitch && codeText.trim().indexOf(":") === -1))) {
+                } else if (!isPrev && (([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1) && (!isSwitch || codeText.trim().indexOf(":") === -1))) {
                     if (codeText.trim().search(/^(private|public|protected)/) === -1 || // False negative - package private Allman
                         codeText.trim().charAt(codeText.trim().length - 1) !== ")") { // False positive - multiline fields ending in )
 
@@ -338,7 +338,7 @@ let indentation_module = {};
                         expectedIndent = currentIndentationWidth;
 
                     }
-                } else if (isPrev && !([";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1 || (isSwitch && codeText.trim().indexOf(":") === -1))) {
+                } else if (isPrev && !((!isSwitch && [";", "{", "}"].indexOf(codeText.trim().charAt(codeText.trim().length - 1)) === -1) && (!isSwitch || codeText.trim().indexOf(":") === -1))) {
                     if (isNotAllman === 0) {
                         isPrev = false;
                     }

--- a/modules/indentation_module.js
+++ b/modules/indentation_module.js
@@ -15,7 +15,8 @@ let indentation_module = {};
     const LastLineIndentationStatus = {
         PROPERLY_INDENTED: 0,
         OVERINDENTED: 1,
-        UNDERINDENTED: 2
+        UNDERINDENTED: 2,
+        MIXED_TABS_AND_SPACES: 3
     }
 
     let moduleColor = "#92b9d1";
@@ -165,7 +166,10 @@ let indentation_module = {};
 
                 let leadingSpace = codeText.substr(0, codeText.indexOf(codeText.trim()));
                 if(!mixTabsAndSpaces && leadingSpace.indexOf(" ") > -1 && leadingSpace.indexOf("\t") > -1) {
-                    lastIssue = new IndentationIssue(trCodeLine, "Mixed Tab and Spaces", "Indent should not mix regular spaces and tabs.", false);
+                    if(lastLineStatus !== LastLineIndentationStatus.MIXED_TABS_AND_SPACES) {
+                        lastLineStatus = LastLineIndentationStatus.MIXED_TABS_AND_SPACES;
+                        lastIssue = new IndentationIssue(trCodeLine, "Mixed Tab and Spaces", "Indent should not mix regular spaces and tabs.", false);
+                    }
                     issuesForFile.push(lastIssue);
 
                 }

--- a/modules/indentation_module.js
+++ b/modules/indentation_module.js
@@ -165,14 +165,6 @@ let indentation_module = {};
                 let codeText = stripStringsFromCode(getCodeFromTrCodeLine(trCodeLine));
 
                 let leadingSpace = codeText.substr(0, codeText.indexOf(codeText.trim()));
-                if(!mixTabsAndSpaces && leadingSpace.indexOf(" ") > -1 && leadingSpace.indexOf("\t") > -1) {
-                    if(lastLineStatus !== LastLineIndentationStatus.MIXED_TABS_AND_SPACES) {
-                        lastLineStatus = LastLineIndentationStatus.MIXED_TABS_AND_SPACES;
-                        lastIssue = new IndentationIssue(trCodeLine, "Mixed Tab and Spaces", "Indent should not mix regular spaces and tabs.", false);
-                    }
-                    issuesForFile.push(lastIssue);
-
-                }
 
                 if (codeText.trim().substr(0, 2) === "//") return;
 
@@ -180,6 +172,9 @@ let indentation_module = {};
                 if (isComment && codeText.indexOf("*/") !== -1) {
                     isComment = false;
                     codeText = codeText.replace(/^((?!\*\/).)*\*\//, " ".repeat(codeText.indexOf("*/") + 2));
+                    if(codeText.trim() === "") {
+                        return;
+                    }
                 }
 
                 // Remove all complete (/* stuff */) multiline comments BEFORE valid code.
@@ -196,6 +191,15 @@ let indentation_module = {};
                 }
 
                 if (isComment) return;
+
+                if(!mixTabsAndSpaces && leadingSpace.indexOf(" ") > -1 && leadingSpace.indexOf("\t") > -1) {
+                    if(lastLineStatus !== LastLineIndentationStatus.MIXED_TABS_AND_SPACES) {
+                        lastLineStatus = LastLineIndentationStatus.MIXED_TABS_AND_SPACES;
+                        lastIssue = new IndentationIssue(trCodeLine, "Mixed Tab and Spaces", "Indent should not mix regular spaces and tabs.", false);
+                    }
+                    issuesForFile.push(lastIssue);
+                }
+
 
                 if (codeText.indexOf("//") !== -1) {
                     codeText = codeText.substr(0, codeText.indexOf("//"));

--- a/modules/spacing_module.js
+++ b/modules/spacing_module.js
@@ -33,9 +33,9 @@ let spacing_module = {};
     }
 
     const MessageEndBySpacingIssueLocality = new Map([
-        [SpacingIssueLocality.BEFORE_OPERATOR, "' needs a single space before it."],
-        [SpacingIssueLocality.AFTER_OPERATOR, "' needs a single space after it."],
-        [SpacingIssueLocality.BEFORE_AND_AFTER_OPERATOR, "' needs a single space before and after it."]
+        [SpacingIssueLocality.BEFORE_OPERATOR, "&#39; needs a single space before it."],
+        [SpacingIssueLocality.AFTER_OPERATOR, "&#39; needs a single space after it."],
+        [SpacingIssueLocality.BEFORE_AND_AFTER_OPERATOR, "&#39; needs a single space before and after it."]
     ])
 
 
@@ -52,7 +52,7 @@ let spacing_module = {};
          */
         constructor(trCodeLine, locality, operator) {
             super(trCodeLine);
-            this.#defaultMessageAndTooltip = "Operator '" + operator + MessageEndBySpacingIssueLocality.get(locality);
+            this.#defaultMessageAndTooltip = "Operator &#39;" + operator + MessageEndBySpacingIssueLocality.get(locality);
             this.#tagName = "Spacing around '" + operator + "'";
             this.#operator = operator;
         }

--- a/sample_options/CMSC131/projects/JavaLoops_CodeGrader_options.json
+++ b/sample_options/CMSC131/projects/JavaLoops_CodeGrader_options.json
@@ -1,90 +1,104 @@
 {
-    "course": "CMSC131",
-    "filesToCheck": [
-        "JavaLoops/src/main/java/programs/Access.java|src/programs/Access.java|programs/Access.java",
-        "JavaLoops/src/main/java/programs/Convert.java|src/programs/Convert.java|programs/Convert.java",
-        "JavaLoops/src/main/java/programs/ThrowDie.java|src/programs/ThrowDie.java|programs/ThrowDie.java"
+    course: 'CMSC131',
+    filesToCheck: [
+        'JavaLoops/src/main/java/programs/Access.java|src/programs/Access.java|programs/Access.java',
+        'JavaLoops/src/main/java/programs/Convert.java|src/programs/Convert.java|programs/Convert.java',
+        'JavaLoops/src/main/java/programs/ThrowDie.java|src/programs/ThrowDie.java|programs/ThrowDie.java',
     ],
-    "lateScoreAdjustment": -12,
-    "moduleOptions": {
-        "brace_style_module": {
-            "enabled": true,
-            "markAllBraces": false
+    firstStudent: 'a',
+    lastStudent: '{',
+    lateScoreAdjustment: -12,
+    moduleOptions: {
+        brace_style_module: {
+            enabled: true,
+            markAllBraces: false,
         },
-        "grade_server_module": {
-            "enabled": true,
-            "gradeServerAssignmentName": "P2",
-            "graderName": "",
-            "maximumCodeStyleScore": 8,
-            "maximumStudentTestsScore": 0,
-            "minimumScoreAdjustment": 0
+        grade_server_module: {
+            customRubricCategories: [],
+            enabled: true,
+            gradeServerAssignmentName: 'P2',
+            graderName: '',
+            maximumCodeStyleScore: 8,
+            maximumStudentTestsScore: 0,
+            minimumScoreAdjustment: 0,
         },
-        "indentation_module": {
-            "enabled": true
+        indentation_module: {
+            enabled: true,
+            ignoreMixedTabsAndSpaces: false,
         },
-        "keyword_and_pattern_module": {
-            "enabled": false,
-            "keywords": [],
-            "patterns": []
+        keyword_and_pattern_module: {
+            enabled: false,
+            keywords: [],
+            patterns: [],
         },
-        "loop_module": {
-            "enabled": false,
-            "methodList": [],
-            "methodListUsage": "disallowed",
-            "showAll": true
+        line_length_module: {
+            enabled: false,
+            lineLengthLimit: 80,
+            tabCharacterWidth: 4,
         },
-        "method_call_module": {
-            "enabled": false,
-            "ignoredMethods": {
-                "global": []
+        loop_module: {
+            enabled: false,
+            methodList: [],
+            methodListUsage: 'disallowed',
+            showAll: true,
+        },
+        method_call_module: {
+            enabled: false,
+            ignoredMethods: {
+                global: [],
             },
-            "ignoredTypes": [],
-            "showUniqueOnly": false
+            ignoredTypes: [],
+            showUniqueOnly: false,
         },
-        "naming_module": {
-            "allowedSpecialWords": [
-                "min",
-                "max",
-                "args"
+        naming_module: {
+            allowedSpecialWords: [
+                'min',
+                'max',
+                'args',
             ],
-            "checkConstants": true,
-            "checkMethods": true,
-            "checkTypes": true,
-            "checkVariablesAndFields": true,
-            "enabled": true,
-            "ignoredNames": {
-                "global": [
-                    "args",
-                    "main"
-                ]
+            checkConstants: true,
+            checkMethods: true,
+            checkTypes: true,
+            checkVariablesAndFields: true,
+            enabled: true,
+            ignoredNames: {
+                global: [
+                    'args',
+                    'main',
+                ],
             },
-            "numbersAllowedInNames": true,
-            "showUniqueOnly": true,
-            "sortAlphabetically": false
+            numbersAllowedInNames: true,
+            showUniqueOnly: true,
+            sortAlphabetically: false,
+            treatInstanceFinalFieldsAsConstants: false,
         },
-        "spacing_module": {
-            "checkSpacingAroundAssignmentOperators": true,
-            "checkSpacingAroundBinaryOperators": true,
-            "enabled": true
+        spacing_module: {
+            checkSpacingAroundAssignmentOperators: true,
+            checkSpacingAroundBinaryOperators: true,
+            enabled: true,
         },
-        "test_module": {
-            "enabled": false,
-            "methodsExpectedToBeTested": []
+        test_module: {
+            enabled: false,
+            methodsExpectedToBeTested: [],
         },
-        "unused_code_module": {
-            "checkMethods": false,
-            "checkTypes": false,
-            "checkVariables": true,
-            "enabled": true,
-            "ignoredNames": {
-                "global": ["args"]
+        unused_code_module: {
+            checkMethods: false,
+            checkTypes: false,
+            checkVariables: true,
+            enabled: true,
+            ignoredNames: {
+                global: [
+                    'args',
+                ],
             },
-            "markAllUsages": false
-        }
+            markAllUsages: false,
+        },
     },
-    "submitServerAssignmentName": "Proj 2",
-    "usageStatisticsOptions": {
-        "anonymizeUser": true,
-        "enabled": true
-    }
+    semesterSeason: 'spring',
+    submitServerAssignmentName: 'Proj 2',
+    usageStatisticsOptions: {
+        anonymizeUser: true,
+        enabled: true,
+    },
+    year: '2022',
 }

--- a/test/Test1.test.js
+++ b/test/Test1.test.js
@@ -1,0 +1,3 @@
+require('jest');
+
+test("AssignmentExpression", )


### PR DESCRIPTION
Several fixes:

- I didn't realize the full implications of reusing the lastLineIssue variables from under/overindents in the mixed tabs and spaces. This fixes a small issue involving this.
- This also fixes the large "comment block" thing you showed me earlier.
- One thing that had been bothering me for a while is that the HTML for the spacing module's comment treats the ' character as a end-quote character, so it would inject the text as code :( Now I've replaced it to fix this.
- Switch statements had faulty logic that's been fixed.